### PR TITLE
get serverDir from env and use npm build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,13 +4,13 @@
  * This is a general purpose Gradle build.
  * Learn how to create Gradle builds at https://guides.gradle.org/creating-new-gradle-builds/
  */
-
 plugins {
     id "com.moowork.node" version "1.2.0"
 }
 
 apply plugin: 'java'
 
+def serverDir = System.getenv("CATALINA_HOME")
 def deployPath = serverDir + "/webapps/" + rootProject.name
 def javaDestPath = deployPath + "/WEB-INF/classes"
 def serverLibPath = serverDir + "/lib"
@@ -75,11 +75,7 @@ task deployJava(type: Copy) {
 deployJava.dependsOn deployLibs, cleanJavaDeploy, seedJava, classes
 
 task buildAngular(type: Exec) {
-    if (System.getProperty("os.name").toUpperCase().contains("WINDOWS")) {
-        commandLine "ng.cmd", "build", "--base-href=/endless-eddies/", "--prod"
-    } else {
-        commandLine "ng", "build", "--base-href=/endless-eddies/", "--prod"
-    }
+    commandLine "npm", "run-script", "build"
 }
 buildAngular.dependsOn npmInstall
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --base-href=/endless-eddies/ --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Hey @MichaelMorrisMM I made a couple changes to the gradle build script.

1. Instead of having to define ```serverDir``` in a different file just read it from the environment.
2. Instead of having the OS checking code just use the npm build script. That should work regardless of OS.

Let me know what you think.