### PR TITLE
move the isExternal check within the correct if block

### DIFF
--- a/src/main/java/User.java
+++ b/src/main/java/User.java
@@ -54,8 +54,8 @@ public class User implements DatabaseObject {
         if (!this.liteMode) {
             this.password = rs.getString("password");
             this.salt = rs.getString("salt");
+            this.isExternal = rs.getString("password").equals("") && rs.getString("salt").equals("");
         }
-        this.isExternal = rs.getString("password").equals("") && rs.getString("salt").equals("");
         try {
             this.storageUsed = StorageManager.getUserStorageSpaceUsed(this);
         } catch (Exception e) {


### PR DESCRIPTION
The assignment to `isExternal` here is throwing an exception when attempting to get the `password` column from the `ResultSet`. I think it just needs to be moved inside the above if block.